### PR TITLE
Fix accolade fermante

### DIFF
--- a/js/mviewerstudio.js
+++ b/js/mviewerstudio.js
@@ -107,7 +107,7 @@ $(document).ready(function(){
             $("#providers_list").append(wms_providers.join(" "));
             if(_conf.data_providers.wms.length > 0) {
                 $("#providers_list").append('<li role="separator" class="divider"></li>');
-
+	    }
             if (API.xml) {
                 loadApplicationParametersFromRemoteFile(API.xml);
             } else if (API.wmc) {
@@ -151,7 +151,6 @@ $(document).ready(function(){
                 mv.hideUserInfo();
             }
         }
-      }
     });
     $('#tabs').tab();
 });


### PR DESCRIPTION
Suite commit https://github.com/geobretagne/mviewerstudio/commit/24ea00a9c9f337ab0058ab87f1539a939ae7048c et fix https://github.com/geobretagne/mviewerstudio/issues/27, une accolade fermante avait été remise trop bas.