### PR TITLE
Fix user_info

### DIFF
--- a/js/mviewerstudio.js
+++ b/js/mviewerstudio.js
@@ -127,7 +127,7 @@ $(document).ready(function(){
             if (_conf.user_info_visible) {
                 $.ajax({
                     type: "GET",
-                    url: "user_info",
+                    url: _conf.user_info,
                     dataType: "json",
                     contentType: "application/json",
                     success: function (data) {


### PR DESCRIPTION
Suite commit https://github.com/geobretagne/mviewerstudio/commit/e9f5ec24837dc375ff00c249da8c2d212502a68c, l'url pour user_info avait été passée en dur, au lieu d'utiliser la valeur dans le fichier de conf.
Ce fix repasse sur la valeur du fichier de conf.