### PR TITLE
Ajout checkbox pour param useproxy

### DIFF
--- a/index.html
+++ b/index.html
@@ -563,11 +563,12 @@
                                                placeholder="metadata-csw">
                                     </div>
                                     <div class="form-group">
-                                        <div class="checkbox">
-                                            <label>
-                                                <input id="frm-secure" type="checkbox"> Donnée protégée
-                                            </label>
-                                        </div>
+                                        <label class="control-label" for="frm-type">Contraintes d'accès</label>
+                                        <select id="frm-secure" name="type" class="form-control">
+                                            <option value="public">Accès public</option>
+                                            <option value="global">Accès soumis à authentification globale (CAS georchestra)</option>
+                                            <option value="layer">Accès soumis à authentification au niveau du service (Basic Authent)</option>
+                                        </select>
                                     </div>
                                     <div class="form-group">
                                         <div class="checkbox">

--- a/index.html
+++ b/index.html
@@ -576,6 +576,13 @@
                                             </label>
                                         </div>
                                     </div>
+                                    <div class="form-group">
+                                        <div class="checkbox">
+                                            <label>
+                                                <input id="frm-useproxy" type="checkbox"> Utiliser le proxy du viewer (nécessaire si HTTPS non disponible pour la couche)
+                                            </label>
+                                        </div>
+                                    </div>
                                 </form>
                             </div>
                             <div role="tabpanel" class="tab-pane" id="layer_conf2">

--- a/index.html
+++ b/index.html
@@ -151,13 +151,6 @@
                                                 Afficher/masquer toutes les données d'une thématique en un clic
                                             </label>
                                         </div>
-                                        <div class="checkbox">
-                                            <label for="opt-hideprotectedlayers">
-                                                <input type="checkbox" name="checkboxes" id="opt-hideprotectedlayers">
-                                                Masquer les couches thématiques en accès restreint
-                                                (lorsqu'elles ne sont pas accessibles)
-                                            </label>
-                                        </div>
                                     </div>
                                 </div>
                             </fieldset>

--- a/js/mviewerstudio.js
+++ b/js/mviewerstudio.js
@@ -194,7 +194,7 @@ var newConfiguration = function () {
         $("#"+param).val("");
     });
     ["opt-exportpng", "opt-measuretools", "theme-edit-collapsed", "opt-mini", "opt-showhelp", "opt-coordinates",
-        "opt-togglealllayersfromtheme", "opt-hideprotectedlayers"].forEach(function (param, id) {
+        "opt-togglealllayersfromtheme"].forEach(function (param, id) {
         $("#"+param).prop('checked', false);
     });
 
@@ -461,8 +461,7 @@ var saveApplicationParameters = function (option) {
         'showhelp="'+($('#opt-showhelp').prop('checked')=== true)+'"',
         'coordinates="'+($('#opt-coordinates').prop('checked')=== true)+'"',
         'measuretools="'+($('#opt-measuretools').prop('checked')=== true)+'"',
-        'togglealllayersfromtheme="'+($('#opt-togglealllayersfromtheme').prop('checked')=== true)+'"',
-        'hideprotectedlayers="'+($('#opt-hideprotectedlayers').prop('checked')=== true)+'"'];
+        'togglealllayersfromtheme="'+($('#opt-togglealllayersfromtheme').prop('checked')=== true)+'"'];
 
     config.title = $("#opt-title").val();
 

--- a/lib/mv.js
+++ b/lib/mv.js
@@ -977,8 +977,8 @@ var mv = (function () {
                 }
             });
 
-            ["exportpng", "measuretools", "showhelp", "coordinates", "togglealllayersfromtheme",
-                "hideprotectedlayers"].forEach(function(value,id) {
+            ["exportpng", "measuretools", "showhelp", "coordinates", 
+                "togglealllayersfromtheme"].forEach(function(value,id) {
                 if (application.attr(value) && application.attr(value) === "true") {
                     $("#opt-" + value).prop("checked", true);
                 }

--- a/lib/mv.js
+++ b/lib/mv.js
@@ -380,7 +380,7 @@ var mv = (function () {
             $("#frm-queryable").prop("checked", (layer.queryable));
             $("#frm-featurecount").val(layer.featurecount);
             $("#frm-infopanel option[value='"+layer.infopanel+"']").prop("selected", true);
-            $("#frm-secure").prop("checked", (layer.secure));
+            $("#frm-secure").val(layer.secure);
             $("#frm-useproxy").prop("checked", (layer.useproxy));
             $("#frm-searchable").prop("checked", (layer.searchable));
             $("#frm-searchengine").val(layer.searchengine).trigger("change");
@@ -498,7 +498,7 @@ var mv = (function () {
             layer.url =  $("#frm-url").val();
             layer.legendurl =  $("#frm-legendurl").val();
             layer.queryable = ($("#frm-queryable").prop("checked") === true);
-            layer.secure = ($("#frm-secure").prop("checked") === true);
+            layer.secure = $("#frm-secure").val();
             layer.useproxy = ($("#frm-useproxy").prop("checked") === true);
             layer.searchable = ($("#frm-searchable").prop("checked") === true);
             layer.searchengine = $("#frm-searchengine").val();
@@ -1046,7 +1046,7 @@ var mv = (function () {
                         searchengine:$(l).attr("searchengine"),
                         fusesearchkeys:$(l).attr("fusesearchkeys"),
                         fusesearchresult:$(l).attr("fusesearchresult"),
-                        secure: ($(l).attr("secure") === "true"),
+                        secure: $(l).attr("secure") || 'public',
                         useproxy: ($(l).attr("useproxy") === "true"),
                         infoformat: $(l).attr("infoformat"),
                         metadata: $(l).attr("metadata"),

--- a/lib/mv.js
+++ b/lib/mv.js
@@ -381,6 +381,7 @@ var mv = (function () {
             $("#frm-featurecount").val(layer.featurecount);
             $("#frm-infopanel option[value='"+layer.infopanel+"']").prop("selected", true);
             $("#frm-secure").prop("checked", (layer.secure));
+            $("#frm-useproxy").prop("checked", (layer.useproxy));
             $("#frm-searchable").prop("checked", (layer.searchable));
             $("#frm-searchengine").val(layer.searchengine).trigger("change");
             $("#frm-fusesearchkeys").val(layer.fusesearchkeys);
@@ -498,6 +499,7 @@ var mv = (function () {
             layer.legendurl =  $("#frm-legendurl").val();
             layer.queryable = ($("#frm-queryable").prop("checked") === true);
             layer.secure = ($("#frm-secure").prop("checked") === true);
+            layer.useproxy = ($("#frm-useproxy").prop("checked") === true);
             layer.searchable = ($("#frm-searchable").prop("checked") === true);
             layer.searchengine = $("#frm-searchengine").val();
             layer.fusesearchkeys = $("#frm-fusesearchkeys").val();
@@ -615,6 +617,7 @@ var mv = (function () {
                     "fusesearchkeys",
                     "fusesearchresult",
                     "secure",
+                    "useproxy",
                     "filter",
                     "sld",
                     "legendurl",
@@ -1044,6 +1047,7 @@ var mv = (function () {
                         fusesearchkeys:$(l).attr("fusesearchkeys"),
                         fusesearchresult:$(l).attr("fusesearchresult"),
                         secure: ($(l).attr("secure") === "true"),
+                        useproxy: ($(l).attr("useproxy") === "true"),
                         infoformat: $(l).attr("infoformat"),
                         metadata: $(l).attr("metadata"),
                         "metadata-csw": $(l).attr("metadata-csw"),


### PR DESCRIPTION
Ajout d'une checkbox dans l'édition de couche d'une thématique (en bas de l'onglet "Base") pour gérer le paramètre useproxy.
Dans mviewer, ce paramètre permet de forcer l'utilisation du proxy (s'il est configuré dans le paramètre <proxy url=...> de la map) pour les appels à la couche concernée. 