### PR TITLE
Disable unused options

### DIFF
--- a/index.html
+++ b/index.html
@@ -538,10 +538,10 @@
                                         <label class="control-label" for="frm-type">Type</label>
                                         <select id="frm-type" name="type" class="form-control"
                                                 onchange="mv.changeLayerType(this.value);">
-                                            <option value="wms">wms</option>
-                                            <option value="geojson">geojson</option>
-                                            <option value="kml">kml</option>
-                                            <option value="customlayer">customlayer</option>
+                                            <option value="wms">WMS</option>
+                                            <option value="geojson" disabled>GeoJSON</option>
+                                            <option value="kml" disabled>KML</option>
+                                            <option value="customlayer" disabled>Customlayer</option>
                                         </select>
                                     </div>
                                     <div class="form-group">
@@ -818,8 +818,8 @@
                                         <label class="control-label" for="frm-searchengine">Moteur de recherche</label>
                                         <select id="frm-searchengine" class="form-control"
                                                 onchange="mv.changeSearchEngine(this.value)">
-                                            <option value="elasticsearch">elasticsearch</option>
-                                            <option value="fuse">fuse</option>
+                                            <option value="elasticsearch">Elasticsearch</option>
+                                            <option value="fuse" disabled>Fuse.js</option>
                                         </select>
                                     </div>
                                     <div id="fuse_options">

--- a/index.html
+++ b/index.html
@@ -302,7 +302,7 @@
                             </div>
                         </div>
                         <p>
-                            La recherche d'entités peut être activée sur les couches de type geojson.
+                            La recherche d'entités peut être activée sur les couches de type GeoJSON.
                         </p>
                         <p>
                             Cette fonctionnalité est également activable pour les couches de type WMS à la condition que les


### PR DESCRIPTION
Pull request related to #62 issue.
I used the "disabled" attribute for options items in order to make them still visible but unselectable.
If you prefer I can comment them out in order to make them totally invisible for the end users.