### PR TITLE
listes des apps, metadata vide

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,0 +1,200 @@
+{
+	"app_conf": {
+        "studio_title": "GéoBretagne mviewer studio",
+        "upload_service": "srv/store.php",
+        "mviewer_instance": "http://dev.mviewerstudio.com/mviewer/",
+        "conf_path_from_mviewer" :"../mviewer/apps/store/",
+        "mviewer_short_url": {
+            "used": true,
+            "apps_folder": "store"
+        },
+        "external_themes": {
+            "used": false,
+            "url": "https://geobretagne.fr/minicatalog/csv"
+        },
+        "user_info": "srv/user_info.php",
+        "export_conf_folder" : "/Users/gillesboisson/Projects/happy_dev/sigat/mviewer/apps/store/",
+        "proxy" : "../proxy/?url=",
+        "user_info_visible": false,
+        "app_form_placeholders": {
+            "app_title": "Kartenn",
+            "logo_url": "https://geobretagne.fr/pub/logo/region-bretagne.jpg",
+            "help_file": "mviewer_help.html"
+        },
+        "map": {
+            "center": [-307903.74898791354, 6141345.088741366],
+            "zoom": 7
+        },
+		"baselayers": {
+			"positron": {
+				"id": "positron",
+				"thumbgallery": "img/basemap/positron.png",
+				"title": "CartoDb",
+				"label": "Positron",
+				"type": "OSM",
+				"url": "https://{a-c}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png",
+				"attribution": "Map tiles by  <a href=\"https://cartodb.com/attributions\">CartoDb</a>, under  <a href=\"https://creativecommons.org/licenses/by/3.0/\">CC BY 3.0 </a>"
+			},
+            "esriworldimagery": {
+				"id": "esriworldimagery",
+				"thumbgallery": "img/basemap/esriworldwide.jpg",
+				"title": "Esri",
+				"label": "Esri world imagery",
+				"type": "OSM",
+				"url": "http://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
+				"attribution": "Esri world imagery"
+			},
+            "stamen1": {
+				"id": "stamen1",
+				"thumbgallery": "img/basemap/toner-lite.png",
+				"title": "Stamen Design",
+				"label": "Toner-lite",
+				"type": "OSM",
+				"url": "http://{a-d}.tile.stamen.com/toner-lite/{z}/{x}/{y}.png",
+				"maxzoom": "20",
+				"attribution": "Map tiles by  <a href=\"http://stamen.com/\">Stamen Design </a>, under  <a href=\"http://creativecommons.org/licenses/by/3.0/\">CC BY 3.0 </a>"
+			},
+            "stamen2": {
+				"id": "stamen2",
+				"thumbgallery": "img/basemap/watercolor.jpg",
+				"title": "Stamen Design",
+				"label": "Watercolor",
+				"type": "OSM",
+				"url": "http://{a-c}.tile.stamen.com/watercolor/{z}/{x}/{y}.jpg",
+				"maxzoom": "20",
+				"attribution": "Map tiles by  <a href=\"http://stamen.com/\">Stamen Design </a>, under  <a href=\"http://creativecommons.org/licenses/by/3.0/\">CC BY 3.0 </a>"
+			},
+            "darkmatter": {
+				"id": "darkmatter",
+				"thumbgallery": "img/basemap/darkmatter.png",
+				"title": "CartoDb",
+				"label": "Dark Matter",
+				"type": "OSM",
+				"url": "https://{a-c}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png",
+				"maxzoom": "20",
+				"attribution": "Map tiles by  <a href=\"https://cartodb.com/attributions\">CartoDb</a>, under  <a href=\"https://creativecommons.org/licenses/by/3.0/\">CC BY 3.0 </a>"
+			},
+            "ortho1": {
+				"id": "ortho1",
+				"thumbgallery": "img/basemap/ortho.jpg",
+				"title": "GéoBretagne",
+				"label": "Photo aérienne actuelle",
+				"type": "WMTS",
+				"url": "https://tile.geobretagne.fr/gwc02/service/wmts",
+                "layers": "satellite",
+                "format": "image/png",
+                "style": "_null",
+                "matrixset": "EPSG:3857",
+                "fromcapacity": "false",
+				"attribution": "<a href=\"https://applications.region-bretagne.fr/geonetwork/?uuid=3a0ac2e3-7af1-4dec-9f36-dae6b5a8c731\" target=\"_blank\" >partenaires GéoBretagne - IGN RGE BD ORTHO - PlanetObserver</a>"
+			},
+             "ortho_ir": {
+				"id": "ortho_ir",
+				"thumbgallery": "img/basemap/ir.jpg",
+				"title": "GéoBretagne",
+				"label": "Photo aérienne infra rouge",
+				"type": "WMTS",
+				"url": "https://geobretagne.fr/geoserver/gwc/service/wmts",
+                "layers": "photo:ir-composite",
+                "format": "image/jpeg",
+                "style": "_null",
+                "matrixset": "EPSG:3857",
+                "fromcapacity": "false",
+				"attribution": "<a href=\"https://applications.region-bretagne.fr/geonetwork/?uuid=434b82a8-8d3c-4d9f-9eb3-0485f1a63eb6\" target=\"_blank\" >partenaires GéoBretagne - IGN RGE BD ORTHO - PlanetObserver</a>"
+			},
+            "osm_google": {
+				"id": "osm_google",
+				"thumbgallery": "img/basemap/osm_google.png",
+				"title": "GéoBretagne",
+				"label": "OpenStreetMap",
+				"type": "WMS",
+				"url": "https://osm.geobretagne.fr/gwc01/service/wms",
+                "layers": "osm:google",
+                "format": "image/png",
+				"attribution": "GéoBretagne. Données : les contributeurs d'<a href=\"https://www.openstreetmap.org/\" target=\"_blank\">OpenStreetMap </a>,  <a href=\"https://www.openstreetmap.org/copyright\" target=\"_blank\">ODbL </a>"
+			},
+            "osm": {
+				"id": "osm",
+				"thumbgallery": "img/basemap/osm.png",
+				"title": "OSM",
+				"label": "OpenStreetMap",
+				"type": "OSM",
+				"url": "https://{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+				"attribution": "Données : les contributeurs d'<a href=\"https://www.openstreetmap.org/\" target=\"_blank\">OpenStreetMap </a><a href=\"https://www.openstreetmap.org/copyright\" target=\"_blank\">ODbL </a>"
+			},
+			"osm_bzh": {
+				"id": "osm_bzh",
+				"thumbgallery": "img/basemap/osm.png",
+				"title": "OSM BZH",
+				"label": "OpenStreetMap en breton",
+				"type": "OSM",
+				"maxzoom": "20",
+				"url": "https://tile.openstreetmap.bzh/br/{z}/{x}/{y}.png",
+				"attribution": "Kendaolerien <a href=\"https://www.openstreetmap.org/copyright\" target=\"_blank\">OpenStreetMap</a>"
+			},
+			"scan_ign": {
+				"id":"scan_ign",
+				"thumbgallery":"img/basemap/scan.jpg",
+				"title":"GéoPortail",
+				"label":"Cartes IGN",
+				"type":"WMTS",
+				"url":"https://geobretagne.fr/geoportail/wmts",
+				"layers":"GEOGRAPHICALGRIDSYSTEMS.MAPS",
+				"format":"image/jpeg",
+				"fromcapacity":"false",
+				"attribution":"<a href='http://www.geoportail.fr/' target='_blank'><img src='https://api.ign.fr/geoportail/api/js/latest/theme/geoportal/img/logo_gp.gif'></a>",
+				"style":"normal",
+				"matrixset":"PM",
+				"maxzoom":"22"},
+			"scan_ign": {
+				"id":"scan_ign",
+				"thumbgallery":"img/basemap/scan-express.jpg",
+				"title":"GéoPortail",
+				"label":"SCAN Express",
+				"type":"WMTS",
+				"url":"https://geobretagne.fr/geoportail/wmts",
+				"layers":"GEOGRAPHICALGRIDSYSTEMS.MAPS.SCAN-EXPRESS.STANDARD",
+				"format":"image/jpeg",
+				"fromcapacity":"false",
+				"attribution":"<a href='http://www.geoportail.fr/' target='_blank'><img src='https://api.ign.fr/geoportail/api/js/latest/theme/geoportal/img/logo_gp.gif'></a>",
+				"style":"normal",
+				"matrixset":"PM",
+				"maxzoom":"22"}
+		},
+        "data_providers" : {
+            "csw" : [
+                {
+                    "title" : "Catalogue GéoBretagne",
+                    "url": "https://geobretagne.fr/geonetwork/srv/fre/csw",
+                    "baseref": "https://geobretagne.fr/geonetwork/srv/eng/catalog.search?node=srv#/metadata/"
+                },
+                {
+                    "title" : "Catalogue Région Bretagne",
+                    "url": "https://applications.region-bretagne.fr/geonetwork/srv/fre/csw",
+                    "baseref": "https://applications.region-bretagne.fr/geonetwork/srv/fre/catalog.search#/metadata/"
+                },
+                {
+                    "title" : "Catalogue de la Région Grand Est",
+                    "url": "https://geobretagne.fr/geonetwork/srv/fre/csw",
+                    "baseref": "https://www.cigalsace.org/geonetwork/"
+                },
+                {
+                    "title" : "Catalogue de la Région Pays de la Loire",
+                    "url": "../proxy/?url=https://www.geopal.org/geonetwork/srv/fre/csw",
+                    "baseref": "https://www.geopal.org/geonetwork/"
+                }
+            ],
+            "wms" : [
+                {
+                    "title" : "Serveur WMS de la Région",
+                    "url": "https://ows.region-bretagne.fr/geoserver/rb/wms"
+                }
+            ]
+        },
+        "default_params" : {
+            "layer": {
+                "info_format": "text/html"
+            }
+        }
+	}
+}


### PR DESCRIPTION
Quand les metadata sont vide une erreur apparait lors du listing des apps. Ceci permet de retourner une valeur vide si aucune donnée est présente
