### PR TITLE
fix(ogc.js): fix get records filter (fix #81)

### DIFF
--- a/lib/ogc.js
+++ b/lib/ogc.js
@@ -69,23 +69,23 @@ var ogc = (function () {
                         </ogc:PropertyIsEqualTo>\
                         <ogc:PropertyIsLike matchCase="false" wildCard="*" singleChar="." escapeChar="!">\
                             <ogc:PropertyName>Title</ogc:PropertyName>\
-                            <ogc:Literal>{query}*</ogc:Literal>\
+                            <ogc:Literal>*{query}*</ogc:Literal>\
                         </ogc:PropertyIsLike>\
                         <ogc:PropertyIsLike matchCase="false" wildCard="*" singleChar="." escapeChar="!">\
                             <ogc:PropertyName>AlternateTitle</ogc:PropertyName>\
-                            <ogc:Literal>{query}*</ogc:Literal>\
+                            <ogc:Literal>*{query}*</ogc:Literal>\
                         </ogc:PropertyIsLike>\
                         <ogc:PropertyIsLike matchCase="false" wildCard="*" singleChar="." escapeChar="!">\
                             <ogc:PropertyName>Abstract</ogc:PropertyName>\
-                            <ogc:Literal>{query}*</ogc:Literal>\
+                            <ogc:Literal>*{query}*</ogc:Literal>\
                         </ogc:PropertyIsLike>\
                         <ogc:PropertyIsLike matchCase="false" wildCard="*" singleChar="." escapeChar="!">\
                             <ogc:PropertyName>Subject</ogc:PropertyName>\
-                            <ogc:Literal>{query}*</ogc:Literal>\
+                            <ogc:Literal>*{query}*</ogc:Literal>\
                         </ogc:PropertyIsLike>\
                         <ogc:PropertyIsLike matchCase="false" wildCard="*" singleChar="." escapeChar="!">\
                             <ogc:PropertyName>OrganisationName</ogc:PropertyName>\
-                            <ogc:Literal>{query}*</ogc:Literal>\
+                            <ogc:Literal>*{query}*</ogc:Literal>\
                         </ogc:PropertyIsLike>\
                     </ogc:Or>\
                 </ogc:And>\

--- a/lib/ogc.js
+++ b/lib/ogc.js
@@ -40,61 +40,53 @@ var ogc = (function () {
         <csw:Constraint version="1.1.0">\
             <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">\
                 <ogc:And>\
-                    <ogc:And>\
-                        <ogc:Or>\
-                            <ogc:PropertyIsLike wildCard="*" singleChar="." escapeChar="!">\
-                                <ogc:PropertyName>Type</ogc:PropertyName>\
-                                <ogc:Literal>dataset</ogc:Literal>\
-                            </ogc:PropertyIsLike>\
-                            <ogc:PropertyIsLike wildCard="*" singleChar="." escapeChar="!">\
-                                <ogc:PropertyName>Type</ogc:PropertyName>\
-                                <ogc:Literal>series</ogc:Literal>\
-                            </ogc:PropertyIsLike>\
-                        </ogc:Or>\
-                    </ogc:And>\
                     <ogc:Or>\
-                        <ogc:Or>\
-                            <ogc:PropertyIsEqualTo matchCase="true">\
-                                <ogc:PropertyName>Title</ogc:PropertyName>\
-                                <ogc:Literal>{query}</ogc:Literal>\
-                            </ogc:PropertyIsEqualTo>\
-                            <ogc:PropertyIsEqualTo matchCase="true">\
-                                <ogc:PropertyName>AlternateTitle</ogc:PropertyName>\
-                                <ogc:Literal>{query}</ogc:Literal>\
-                            </ogc:PropertyIsEqualTo>\
-                            <ogc:PropertyIsEqualTo matchCase="true">\
-                                <ogc:PropertyName>Identifier</ogc:PropertyName>\
-                                <ogc:Literal>{query}</ogc:Literal>\
-                            </ogc:PropertyIsEqualTo>\
-                            <ogc:PropertyIsEqualTo matchCase="true">\
-                                <ogc:PropertyName>ResourceIdentifier</ogc:PropertyName>\
-                                <ogc:Literal>{query}</ogc:Literal>\
-                            </ogc:PropertyIsEqualTo>\
-                        </ogc:Or>\
-                        <ogc:And>\
-                            <ogc:Or>\
-                                <ogc:PropertyIsLike matchCase="false" wildCard="*" singleChar="." escapeChar="!">\
-                                    <ogc:PropertyName>Title</ogc:PropertyName>\
-                                    <ogc:Literal>{query}*</ogc:Literal>\
-                                </ogc:PropertyIsLike>\
-                                <ogc:PropertyIsLike matchCase="false" wildCard="*" singleChar="." escapeChar="!">\
-                                    <ogc:PropertyName>AlternateTitle</ogc:PropertyName>\
-                                    <ogc:Literal>{query}*</ogc:Literal>\
-                                </ogc:PropertyIsLike>\
-                                <ogc:PropertyIsLike matchCase="false" wildCard="*" singleChar="." escapeChar="!">\
-                                    <ogc:PropertyName>Abstract</ogc:PropertyName>\
-                                    <ogc:Literal>{query}*</ogc:Literal>\
-                                </ogc:PropertyIsLike>\
-                                <ogc:PropertyIsLike matchCase="false" wildCard="*" singleChar="." escapeChar="!">\
-                                    <ogc:PropertyName>Subject</ogc:PropertyName>\
-                                    <ogc:Literal>{query}*</ogc:Literal>\
-                                </ogc:PropertyIsLike>\
-                                <ogc:PropertyIsLike matchCase="false" wildCard="*" singleChar="." escapeChar="!">\
-                                    <ogc:PropertyName>OrganisationName</ogc:PropertyName>\
-                                    <ogc:Literal>{query}*</ogc:Literal>\
-                                </ogc:PropertyIsLike>\
-                            </ogc:Or>\
-                        </ogc:And>\
+                        <ogc:PropertyIsLike wildCard="*" singleChar="." escapeChar="!">\
+                            <ogc:PropertyName>Type</ogc:PropertyName>\
+                            <ogc:Literal>dataset</ogc:Literal>\
+                        </ogc:PropertyIsLike>\
+                        <ogc:PropertyIsLike wildCard="*" singleChar="." escapeChar="!">\
+                            <ogc:PropertyName>Type</ogc:PropertyName>\
+                            <ogc:Literal>series</ogc:Literal>\
+                        </ogc:PropertyIsLike>\
+                    </ogc:Or>\
+                    <ogc:Or>\
+                        <ogc:PropertyIsEqualTo matchCase="true">\
+                            <ogc:PropertyName>Title</ogc:PropertyName>\
+                            <ogc:Literal>{query}</ogc:Literal>\
+                        </ogc:PropertyIsEqualTo>\
+                        <ogc:PropertyIsEqualTo matchCase="true">\
+                            <ogc:PropertyName>AlternateTitle</ogc:PropertyName>\
+                            <ogc:Literal>{query}</ogc:Literal>\
+                        </ogc:PropertyIsEqualTo>\
+                        <ogc:PropertyIsEqualTo matchCase="true">\
+                            <ogc:PropertyName>Identifier</ogc:PropertyName>\
+                            <ogc:Literal>{query}</ogc:Literal>\
+                        </ogc:PropertyIsEqualTo>\
+                        <ogc:PropertyIsEqualTo matchCase="true">\
+                            <ogc:PropertyName>ResourceIdentifier</ogc:PropertyName>\
+                            <ogc:Literal>{query}</ogc:Literal>\
+                        </ogc:PropertyIsEqualTo>\
+                        <ogc:PropertyIsLike matchCase="false" wildCard="*" singleChar="." escapeChar="!">\
+                            <ogc:PropertyName>Title</ogc:PropertyName>\
+                            <ogc:Literal>{query}*</ogc:Literal>\
+                        </ogc:PropertyIsLike>\
+                        <ogc:PropertyIsLike matchCase="false" wildCard="*" singleChar="." escapeChar="!">\
+                            <ogc:PropertyName>AlternateTitle</ogc:PropertyName>\
+                            <ogc:Literal>{query}*</ogc:Literal>\
+                        </ogc:PropertyIsLike>\
+                        <ogc:PropertyIsLike matchCase="false" wildCard="*" singleChar="." escapeChar="!">\
+                            <ogc:PropertyName>Abstract</ogc:PropertyName>\
+                            <ogc:Literal>{query}*</ogc:Literal>\
+                        </ogc:PropertyIsLike>\
+                        <ogc:PropertyIsLike matchCase="false" wildCard="*" singleChar="." escapeChar="!">\
+                            <ogc:PropertyName>Subject</ogc:PropertyName>\
+                            <ogc:Literal>{query}*</ogc:Literal>\
+                        </ogc:PropertyIsLike>\
+                        <ogc:PropertyIsLike matchCase="false" wildCard="*" singleChar="." escapeChar="!">\
+                            <ogc:PropertyName>OrganisationName</ogc:PropertyName>\
+                            <ogc:Literal>{query}*</ogc:Literal>\
+                        </ogc:PropertyIsLike>\
                     </ogc:Or>\
                 </ogc:And>\
             </ogc:Filter>\
@@ -117,9 +109,9 @@ var ogc = (function () {
         }
 
         if (query) {
-            return _cswGetRecordQueryTemplate.replace("{resultType}", _resultType).replace("{query}", query).replace("{typeNames}", _typeNames);
+            return _cswGetRecordQueryTemplate.replace(/{resultType}/g, _resultType).replace(/{query}/g, query).replace(/{typeNames}/g, _typeNames);
         } else {
-            return _cswEmptyGetRecordQuery.replace("{resultType}", _resultType).replace("{typeNames}", _typeNames);
+            return _cswEmptyGetRecordQuery.replace(/{resultType}/g, _resultType).replace(/{typeNames}/g, _typeNames);
         }
     };
 


### PR DESCRIPTION
Correctif pour le ticket #81 :
* remplacement de toutes les occurrences de `{query} `dans le filtre CSW
* simplification (sans perte de sens) des tags `<ogc:Or>` et `<ogc:And>` dans le filtre CSW