### PR TITLE
Fixing CI by adding magical env var

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,8 @@ jobs:
         run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
 
       - name: "build the docker containers"
+        env:
+          DOCKER_BUILDKIT: 1
         run: |
           docker-compose build
 


### PR DESCRIPTION
Fixing #103 (at least trying)
Following this issue, https://github.com/moby/moby/issues/37965 adding
DOCKER_BUILDKIT env var make the build working.